### PR TITLE
fix(docker-compose): SASS watcher when using docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,4 +114,7 @@ dist
 
 # generated CSS
 public/styles.css
+public/styles/
+
+# local database
 data.db

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,16 @@
 services:
+  sass-watch:
+    profiles:
+    - couchdb
+    - sqlite
+    build:
+      context: .
+      target: prod
+    command: yarn sass:dev
+    volumes:
+    - ./src:/opt/epp/src
+    - styles:/opt/epp/public/styles
+
   # SQLite profile
   app-sqlite:
     profiles:
@@ -14,6 +26,7 @@ services:
     volumes:
     - ./src:/opt/epp/src
     - epp-data:/opt/epp-data
+    - styles:/opt/epp/public/styles
 
   # couchdb profile
   app-couchdb:
@@ -36,6 +49,7 @@ services:
     volumes:
     - ./src:/opt/epp/src
     - epp-data:/opt/epp-data
+    - styles:/opt/epp/public/styles
   couchdb:
     profiles:
     - couchdb
@@ -65,3 +79,4 @@ services:
 volumes:
   epp-data:
   couchdb:
+  styles:

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "start:dev": "nodemon src/server.ts",
     "test": "jest",
     "lint": "eslint --ext .ts src/",
-    "sass": "sass --no-source-map src/sass/style.scss:public/styles.css",
+    "sass": "sass --no-source-map src/sass/style.scss:public/styles/styles.css",
     "sass:dev": "nodemon -e scss -x \"yarn sass\"",
     "docker-build": "docker build . -t epp-node",
     "docker-start": "docker run --rm -p 3000:3000 epp-node:latest"

--- a/src/base-page/base-page.ts
+++ b/src/base-page/base-page.ts
@@ -6,7 +6,7 @@ export const basePage = (pageContent: string, noHeader: boolean = false): string
         <meta http-equiv="X-UA-Compatible" content="ie=edge">
         <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;600&family=Noto+Serif" rel="stylesheet">
         <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-        <link rel="stylesheet" href="/styles.css"/>
+        <link rel="stylesheet" href="/styles/styles.css"/>
       </head>
       <body>
         <div class="grid-container">


### PR DESCRIPTION
- Create a sass watcher service
- Mount a volume between that and the app's container to share the output CSS
- Alter the app to account for new path (needed for sharing a volume)

fixes elifesciences/enhanced-preprints-issues#222