### PR TITLE
fix: docker-compose is missing config for iiif server

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,6 +28,7 @@ services:
       REPO_CONNECTION: mongodb:27017
       REPO_USERNAME: admin
       REPO_PASSWORD: testtest
+      IIIF_SERVER: http://localhost:8182
     ports:
       - "8080:3000"
     volumes:


### PR DESCRIPTION
Straightforward issue: the server runs currently, but it's embedding images again because of missing env var config for iiif server, probably lost when we removed all other backends.