### PR TITLE
Revert "Update dependency @types/node to v16.18.14"

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@types/eslint": "8.21.1",
     "@types/express": "4.17.17",
     "@types/jest": "29.4.0",
-    "@types/node": "16.18.14",
+    "@types/node": "16.18.13",
     "@types/supertest": "^2.0.12",
     "@typescript-eslint/eslint-plugin": "5.54.0",
     "@typescript-eslint/parser": "5.54.0",

--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true
+      "automerge": false
     },
     {
       "matchPackageNames": ["node"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4283,10 +4283,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:16.18.14":
-  version: 16.18.14
-  resolution: "@types/node@npm:16.18.14"
-  checksum: 7865c1c3e7c7d2fef6103c6dfa181755dc48365024253d6acc460e884508b5937a222aa8bd04835988ff0bdc47867e2ada78859c0a7f9c65b44884316f3b469c
+"@types/node@npm:16.18.13":
+  version: 16.18.13
+  resolution: "@types/node@npm:16.18.13"
+  checksum: c284f97a0630d65887be0e0d7ef8e5e5022eb4916ffae142db07f22dad565a80f17b6a84f21b4521c707f642540430710a8aa5930a2cf2bcbecde0a476ff9c02
   languageName: node
   linkType: hard
 
@@ -7224,7 +7224,7 @@ __metadata:
     "@types/eslint": 8.21.1
     "@types/express": 4.17.17
     "@types/jest": 29.4.0
-    "@types/node": 16.18.14
+    "@types/node": 16.18.13
     "@types/supertest": ^2.0.12
     "@typescript-eslint/eslint-plugin": 5.54.0
     "@typescript-eslint/parser": 5.54.0


### PR DESCRIPTION
Reverts elifesciences/enhanced-preprints-server#601

Reverting Renovate's mess of a node update (it's preventing me pulling master into mine and @scottaubrey's datahub branch)