### PR TITLE
Revert to node 16.18.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG node_version=16.19-alpine3.15
+ARG node_version=16.18-alpine3.15
 
 FROM node:${node_version} as base
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@types/eslint": "8.21.1",
     "@types/express": "4.17.17",
     "@types/jest": "29.4.0",
-    "@types/node": "16.18.14",
+    "@types/node": "16.18.13",
     "@types/supertest": "^2.0.12",
     "@typescript-eslint/eslint-plugin": "5.54.0",
     "@typescript-eslint/parser": "5.54.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@types/eslint": "8.21.1",
     "@types/express": "4.17.17",
     "@types/jest": "29.4.0",
-    "@types/node": "16.18.13",
+    "@types/node": "16.18.10",
     "@types/supertest": "^2.0.12",
     "@typescript-eslint/eslint-plugin": "5.54.0",
     "@typescript-eslint/parser": "5.54.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4283,10 +4283,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:16.18.14":
-  version: 16.18.14
-  resolution: "@types/node@npm:16.18.14"
-  checksum: 7865c1c3e7c7d2fef6103c6dfa181755dc48365024253d6acc460e884508b5937a222aa8bd04835988ff0bdc47867e2ada78859c0a7f9c65b44884316f3b469c
+"@types/node@npm:16.18.13":
+  version: 16.18.13
+  resolution: "@types/node@npm:16.18.13"
+  checksum: c284f97a0630d65887be0e0d7ef8e5e5022eb4916ffae142db07f22dad565a80f17b6a84f21b4521c707f642540430710a8aa5930a2cf2bcbecde0a476ff9c02
   languageName: node
   linkType: hard
 
@@ -7224,7 +7224,7 @@ __metadata:
     "@types/eslint": 8.21.1
     "@types/express": 4.17.17
     "@types/jest": 29.4.0
-    "@types/node": 16.18.14
+    "@types/node": 16.18.13
     "@types/supertest": ^2.0.12
     "@typescript-eslint/eslint-plugin": 5.54.0
     "@typescript-eslint/parser": 5.54.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -4283,10 +4283,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:16.18.13":
-  version: 16.18.13
-  resolution: "@types/node@npm:16.18.13"
-  checksum: c284f97a0630d65887be0e0d7ef8e5e5022eb4916ffae142db07f22dad565a80f17b6a84f21b4521c707f642540430710a8aa5930a2cf2bcbecde0a476ff9c02
+"@types/node@npm:16.18.10":
+  version: 16.18.10
+  resolution: "@types/node@npm:16.18.10"
+  checksum: 1b138616923e9a1c6d3806edf75714b605d2ec689357cdc675bc73816c508ff11b3c68df054b02a496c76654d8ed53add2e90816af39423431c73aa6eec06f29
   languageName: node
   linkType: hard
 
@@ -7224,7 +7224,7 @@ __metadata:
     "@types/eslint": 8.21.1
     "@types/express": 4.17.17
     "@types/jest": 29.4.0
-    "@types/node": 16.18.13
+    "@types/node": 16.18.10
     "@types/supertest": ^2.0.12
     "@typescript-eslint/eslint-plugin": 5.54.0
     "@typescript-eslint/parser": 5.54.0


### PR DESCRIPTION
Switching back to node 16.18.10 until we resolve the issues with `docker compose up` failing locally.

This is the error we are seeing. We should as a follow up introduce a test which would have prevented the renovate PR from passing it would trigger this error:
```
$ docker compose up --build
[+] Building 1.2s (3/3) FINISHED                                                                                                                                                                                           
 => [internal] load .dockerignore                                                                                                                                                                                     0.0s
 => => transferring context: 102B                                                                                                                                                                                     0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                                  0.0s
 => => transferring dockerfile: 639B                                                                                                                                                                                  0.0s
 => ERROR [internal] load metadata for docker.io/library/node:16.19-alpine3.15                                                                                                                                        1.1s
------
 > [internal] load metadata for docker.io/library/node:16.19-alpine3.15:
------
failed to solve: node:16.19-alpine3.15: docker.io/library/node:16.19-alpine3.15: not found
```