### PR TITLE
Give epp-server container images better repository name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,9 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           load: true
-          tags: ghcr.io/elifesciences/enhanced-preprints:test
+          tags: |
+            ghcr.io/elifesciences/enhanced-preprints:test
+            ghcr.io/elifesciences/enhanced-preprints-server:test
   build-and-push:
     needs: [test]
     runs-on: ubuntu-latest
@@ -75,4 +77,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/elifesciences/enhanced-preprints:latest
+            ghcr.io/elifesciences/enhanced-preprints-server:latest
             ghcr.io/elifesciences/enhanced-preprints:master-${{ steps.commit_sha.outputs.commit_sha }}-${{ steps.date.outputs.date }}
+            ghcr.io/elifesciences/enhanced-preprints-server:master-${{ steps.commit_sha.outputs.commit_sha }}-${{ steps.date.outputs.date }}

--- a/.github/workflows/preview-build.yaml
+++ b/.github/workflows/preview-build.yaml
@@ -30,3 +30,4 @@ jobs:
           platforms: linux/amd64
           tags: |
             ghcr.io/elifesciences/enhanced-preprints:preview-${{ steps.commit_sha.outputs.commit_sha }}
+            ghcr.io/elifesciences/enhanced-preprints-server:preview-${{ steps.commit_sha.outputs.commit_sha }}


### PR DESCRIPTION
change the server image tag to match the naming scheme of other EPP images.

Publishing to both tags will allow us to migrate the name in other projects a bit at a time.