### PR TITLE
feat: add publishedYear to various schemas and tests

### DIFF
--- a/integration-tests/api.test.ts
+++ b/integration-tests/api.test.ts
@@ -691,6 +691,7 @@ describe('server tests', () => {
       preprintPosted: '2023-01-02T00:00:00.000Z',
       sentForReview: '2023-01-03T00:00:00.000Z',
       published: '2023-01-23T00:00:00.000Z',
+      publishedYear: '2023',
     };
 
     const versionSummary = {
@@ -706,6 +707,7 @@ describe('server tests', () => {
       preprintPosted: '2023-01-02T00:00:00.000Z',
       sentForReview: '2023-01-03T00:00:00.000Z',
       published: '2023-01-23T00:00:00.000Z',
+      publishedYear: '2023',
     };
 
     it('imports a valid JSON body', async () => {

--- a/src/http-schema/http-schema.test.ts
+++ b/src/http-schema/http-schema.test.ts
@@ -222,6 +222,7 @@ describe('httpschema', () => {
       volume: '1',
       eLocationId: 'RP12356',
       versionDoi: '10.7554/123456',
+      publishedYear: '2023',
       sentForReview: '2023-07-31',
       peerReview: {
         evaluationSummary: {

--- a/src/http-schema/http-schema.ts
+++ b/src/http-schema/http-schema.ts
@@ -226,4 +226,7 @@ export const EnhancedArticleSchema = Joi.object<EnhancedArticle>({
   sentForReview: Joi.date().optional(),
   peerReview: PeerReviewSchema.optional(),
   published: Joi.date().optional(),
+  publishedYear: Joi.string()
+    .regex(/^[1-9][0-9]{3}$/)
+    .optional(),
 });

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -141,6 +141,7 @@ export type EnhancedArticle = {
   sentForReview?: Date,
   peerReview?: PeerReview,
   published?: Date,
+  publishedYear?: string,
 };
 
 export type EnhancedArticleWithVersions = {


### PR DESCRIPTION
This commit includes the addition of the `publishedYear` property to the
http-schema.ts, model.ts, and api.test.ts files. This property has also been
added to respective test files to ensure its correct functioning.