### PR TITLE
feat: change publishedYear type from string to number

### DIFF
--- a/integration-tests/api.test.ts
+++ b/integration-tests/api.test.ts
@@ -691,7 +691,7 @@ describe('server tests', () => {
       preprintPosted: '2023-01-02T00:00:00.000Z',
       sentForReview: '2023-01-03T00:00:00.000Z',
       published: '2023-01-23T00:00:00.000Z',
-      publishedYear: '2023',
+      publishedYear: 2023,
     };
 
     const versionSummary = {
@@ -707,7 +707,7 @@ describe('server tests', () => {
       preprintPosted: '2023-01-02T00:00:00.000Z',
       sentForReview: '2023-01-03T00:00:00.000Z',
       published: '2023-01-23T00:00:00.000Z',
-      publishedYear: '2023',
+      publishedYear: 2023,
     };
 
     it('imports a valid JSON body', async () => {

--- a/src/http-schema/http-schema.test.ts
+++ b/src/http-schema/http-schema.test.ts
@@ -198,6 +198,9 @@ describe('httpschema', () => {
   it.each([
     [{}, allRequiredFieldValidationMessages],
     [{ id: '12345', msid: 1 }, [{ message: '"msid" must be a string' }, ...sampleRequiredFieldValidationMessages]],
+    [{ publishedYear: 'one' }, [...allRequiredFieldValidationMessages, { message: '"publishedYear" must be a number' }]],
+    // Verify that publishedYear can also be a numeric string.
+    [{ publishedYear: '2023' }, [...allRequiredFieldValidationMessages]],
     [{ unknown: 'unknown' }, [...allRequiredFieldValidationMessages, { message: '"unknown" is not allowed' }]],
     [{ unknown1: 'unknown', unknown2: 'unknown' }, [...allRequiredFieldValidationMessages, { message: '"unknown1" is not allowed' }, { message: '"unknown2" is not allowed' }]],
   ])('handles validation error', (value, errorDetails) => {
@@ -214,6 +217,17 @@ describe('httpschema', () => {
     expect(enhancedArticle.value?.preprintPosted).toStrictEqual(new Date('2023-01-02'));
     expect(enhancedArticle.value?.sentForReview).toStrictEqual(new Date('2023-01-03'));
     expect(enhancedArticle.value?.published).toStrictEqual(new Date('2023-01-23'));
+  });
+
+  it('will convert publishedYear to number from string', () => {
+    const enhancedArticle = EnhancedArticleSchema.validate({
+      ...enhancedArticleExample,
+      publishedYear: '2023',
+    });
+
+    expect(enhancedArticle.error).toBeUndefined();
+    expect(typeof enhancedArticle.value?.publishedYear).toStrictEqual('number');
+    expect(enhancedArticle.value?.publishedYear).toStrictEqual(2023);
   });
 
   it('parses optional values', () => {

--- a/src/http-schema/http-schema.ts
+++ b/src/http-schema/http-schema.ts
@@ -226,7 +226,7 @@ export const EnhancedArticleSchema = Joi.object<EnhancedArticle>({
   sentForReview: Joi.date().optional(),
   peerReview: PeerReviewSchema.optional(),
   published: Joi.date().optional(),
-  publishedYear: Joi.string()
-    .regex(/^[1-9][0-9]{3}$/)
+  publishedYear: Joi.number()
+    .integer()
     .optional(),
 });

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -141,7 +141,7 @@ export type EnhancedArticle = {
   sentForReview?: Date,
   peerReview?: PeerReview,
   published?: Date,
-  publishedYear?: string,
+  publishedYear?: number,
 };
 
 export type EnhancedArticleWithVersions = {


### PR DESCRIPTION
This commit changes the publishedYear type from string to number in various files. It also adds tests to ensure that the publishedYear value is correctly converted from string to number.