### PR TITLE
feat: Update mock data and schema for Claim and QuoteBlock

### DIFF
--- a/integration-tests/mock-data/mock-body-1.json
+++ b/integration-tests/mock-data/mock-body-1.json
@@ -1029,6 +1029,28 @@
         "text": "train_test_split()"
       },
       {
+        "type": "Claim",
+        "content": [
+          {
+            "type": "Paragraph",
+            "content": [
+              "This is a claim"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "QuoteBlock",
+        "content": [
+          {
+            "type": "Paragraph",
+            "content": [
+              "This is a quote block"
+            ]
+          }
+        ]
+      },
+      {
         "type": "Paragraph",
         "content": [
           " function in the "

--- a/src/http-schema/http-schema.test.ts
+++ b/src/http-schema/http-schema.test.ts
@@ -163,6 +163,9 @@ describe('httpschema', () => {
           id: 'h1',
         },
       ],
+      content: [
+        'Claim content',
+      ],
     },
     [
       [{

--- a/src/http-schema/http-schema.test.ts
+++ b/src/http-schema/http-schema.test.ts
@@ -164,16 +164,6 @@ describe('httpschema', () => {
         },
       ],
     },
-    {
-      type: 'Claim',
-      label: 'This is a label',
-      content: [
-        {
-          type: 'paragraph',
-          content: 'This is a claim',
-        },
-      ],
-    },
     [
       [{
         type: 'Heading', depth: 1, content: 'heading', id: 'h1',

--- a/src/http-schema/http-schema.test.ts
+++ b/src/http-schema/http-schema.test.ts
@@ -164,6 +164,16 @@ describe('httpschema', () => {
         },
       ],
     },
+    {
+      type: 'Claim',
+      label: 'This is a label',
+      content: [
+        {
+          type: 'paragraph',
+          content: 'This is a claim',
+        },
+      ],
+    },
     [
       [{
         type: 'Heading', depth: 1, content: 'heading', id: 'h1',

--- a/src/http-schema/http-schema.ts
+++ b/src/http-schema/http-schema.ts
@@ -49,9 +49,10 @@ const ListContentSchema = Joi.object({
 
 const ClaimContentSchema = Joi.object({
   type: Joi.string().valid('Claim').required(),
-  claimType: Joi.string().valid('Statement', 'Theorem', 'Lemma', 'Proof', 'Postulate', 'Hypothesis', 'Proposition', 'Corollary').required(),
+  claimType: Joi.string().valid('Statement', 'Theorem', 'Lemma', 'Proof', 'Postulate', 'Hypothesis', 'Proposition', 'Corollary').optional(),
   label: Joi.link('#Content').optional(),
   title: Joi.link('#Content').optional(),
+  content: Joi.link('#Content').optional(),
 });
 
 const LinkContentSchema = Joi.object({
@@ -98,7 +99,7 @@ const ImageObjectContent = Joi.object({
 
 // These are not imported yet
 const OtherContent = Joi.object({
-  type: Joi.string().valid('CodeBlock', 'MathFragment', 'MediaObject', 'Table', 'ThematicBreak'),
+  type: Joi.string().valid('CodeBlock', 'MathFragment', 'MediaObject', 'QuoteBlock', 'Table', 'ThematicBreak'),
 });
 // end block
 

--- a/src/http-schema/http-schema.ts
+++ b/src/http-schema/http-schema.ts
@@ -52,7 +52,7 @@ const ClaimContentSchema = Joi.object({
   claimType: Joi.string().valid('Statement', 'Theorem', 'Lemma', 'Proof', 'Postulate', 'Hypothesis', 'Proposition', 'Corollary').optional(),
   label: Joi.link('#Content').optional(),
   title: Joi.link('#Content').optional(),
-  content: Joi.link('#Content').optional(),
+  content: Joi.link('#Content').required(),
 });
 
 const LinkContentSchema = Joi.object({

--- a/src/model/content.ts
+++ b/src/model/content.ts
@@ -80,7 +80,7 @@ type ListContent = {
 
 type ClaimContent = DecoratedContent & {
   type: 'Claim',
-  claimType: 'Statement' | 'Theorem' | 'Lemma' | 'Proof' | 'Postulate' | 'Hypothesis' | 'Proposition' | 'Corollary',
+  claimType?: 'Statement' | 'Theorem' | 'Lemma' | 'Proof' | 'Postulate' | 'Hypothesis' | 'Proposition' | 'Corollary',
   label?: Content,
   title?: Content,
 };


### PR DESCRIPTION
This commit introduces changes to integration tests' mock data by adding a 'Claim' and a 'QuoteBlock'. Corresponding test cases are added in http-schema.test.ts. The http-schema.ts is updated to modify the claimType in ClaimContentSchema to be optional and add a new content field. Also, the 'QuoteBlock' option is added to the OtherContent object.