### PR TITLE
feat: add pagination and sorting to getEnhancedArticlesNoContent

### DIFF
--- a/integration-tests/api.test.ts
+++ b/integration-tests/api.test.ts
@@ -1150,7 +1150,8 @@ describe('server tests', () => {
         .get('/api/preprints-no-content')
         .expect(200)
         .expect((response) => {
-          expect(response.header.get('X-Total-Count')).toBe('1');
+          expect(response.header.has('x-total-count')).toBe(true);
+          expect(response.header['x-total-count']).toBe('1');
           expect(response.body.length).toBe(1);
           expect(response.body[0]).toEqual({
             id: 'testid4',

--- a/integration-tests/api.test.ts
+++ b/integration-tests/api.test.ts
@@ -1150,7 +1150,6 @@ describe('server tests', () => {
         .get('/api/preprints-no-content')
         .expect(200)
         .expect((response) => {
-          expect(response.header.has('x-total-count')).toBe(true);
           expect(response.header['x-total-count']).toBe('1');
           expect(response.body.length).toBe(1);
           expect(response.body[0]).toEqual({

--- a/integration-tests/api.test.ts
+++ b/integration-tests/api.test.ts
@@ -1128,6 +1128,28 @@ describe('server tests', () => {
         },
         published: null,
       };
+      const exampleVersion3 = {
+        ...enhancedArticle,
+        id: 'testid6',
+        versionIdentifier: '1',
+        msid: 'article.3',
+        published: '2023-01-24T00:00:00.000Z',
+      };
+      const exampleVersion4 = {
+        ...enhancedArticle,
+        id: 'testid7',
+        versionIdentifier: '1',
+        msid: 'article.4',
+        published: `${new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().split('T')[0]}T00:00:00.000Z`,
+      };
+      const exampleVersion5 = {
+        ...enhancedArticle,
+        id: 'testid8',
+        versionIdentifier: '1',
+        msid: 'article.5',
+        published: '2023-01-22T00:00:00.000Z',
+        subjects: ['subject 3'],
+      };
 
       await request(app)
         .post('/preprints')
@@ -1145,14 +1167,68 @@ describe('server tests', () => {
           result: true,
           message: 'OK',
         });
+      await request(app)
+        .post('/preprints')
+        .send(exampleVersion3)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+        .expect((200), {
+          result: true,
+          message: 'OK',
+        });
+      await request(app)
+        .post('/preprints')
+        .send(exampleVersion4)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+        .expect((200), {
+          result: true,
+          message: 'OK',
+        });
+      await request(app)
+        .post('/preprints')
+        .send(exampleVersion5)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+        .expect((200), {
+          result: true,
+          message: 'OK',
+        });
 
       await request(app)
         .get('/api/preprints-no-content')
         .expect(200)
         .expect((response) => {
-          expect(response.header['x-total-count']).toBe('1');
-          expect(response.body.length).toBe(1);
+          expect(response.header['x-total-count']).toBe('3');
+          expect(response.body.length).toBe(3);
           expect(response.body[0]).toEqual({
+            id: 'testid6',
+            msid: 'article.3',
+            doi: 'doi1',
+            volume: '1',
+            eLocationId: 'RPtestid3',
+            versionIdentifier: '1',
+            versionDoi: 'publisher/testid1',
+            article: {
+              title: 'test article',
+              authors: [
+                {
+                  familyNames: ['Daffy'],
+                  givenNames: ['Duck'],
+                  affiliations: [{ name: 'ACME Labs' }],
+                  emails: ['daffy.duck@acme.org'],
+                },
+              ],
+              licenses: [],
+              references: [],
+            },
+            preprintDoi: 'preprint/testid1',
+            preprintUrl: 'doi.org/preprint/testid1',
+            preprintPosted: '2023-01-02T00:00:00.000Z',
+            sentForReview: '2023-01-03T00:00:00.000Z',
+            published: '2023-01-24T00:00:00.000Z',
+            publishedYear: 2023,
+            subjects: ['subject 1', 'subject 2'],
+            license: 'https://creativecommons.org/licenses/by/4.0/',
+          });
+          expect(response.body[1]).toEqual({
             id: 'testid4',
             msid: 'article.2',
             doi: 'doi1',
@@ -1182,6 +1258,90 @@ describe('server tests', () => {
             subjects: ['subject 1', 'subject 2'],
             license: 'https://creativecommons.org/licenses/by/4.0/',
           });
+          expect(response.body[2]).toEqual({
+            id: 'testid8',
+            msid: 'article.5',
+            doi: 'doi1',
+            volume: '1',
+            eLocationId: 'RPtestid3',
+            versionIdentifier: '1',
+            versionDoi: 'publisher/testid1',
+            article: {
+              title: 'test article',
+              authors: [
+                {
+                  familyNames: ['Daffy'],
+                  givenNames: ['Duck'],
+                  affiliations: [{ name: 'ACME Labs' }],
+                  emails: ['daffy.duck@acme.org'],
+                },
+              ],
+              licenses: [],
+              references: [],
+            },
+            preprintDoi: 'preprint/testid1',
+            preprintUrl: 'doi.org/preprint/testid1',
+            preprintPosted: '2023-01-02T00:00:00.000Z',
+            sentForReview: '2023-01-03T00:00:00.000Z',
+            published: '2023-01-22T00:00:00.000Z',
+            publishedYear: 2023,
+            subjects: ['subject 3'],
+            license: 'https://creativecommons.org/licenses/by/4.0/',
+          });
+        });
+
+      await request(app)
+        .get('/api/preprints-no-content?per-page=1&page=1')
+        .expect(200)
+        .expect((response) => {
+          expect(response.header['x-total-count']).toBe('3');
+          expect(response.body.length).toBe(1);
+          expect(response.body[0].id).toBe('testid6');
+        });
+
+      await request(app)
+        .get('/api/preprints-no-content?per-page=1&page=2')
+        .expect(200)
+        .expect((response) => {
+          expect(response.header['x-total-count']).toBe('3');
+          expect(response.body.length).toBe(1);
+          expect(response.body[0].id).toBe('testid4');
+        });
+
+      await request(app)
+        .get('/api/preprints-no-content?per-page=1&page=3')
+        .expect(200)
+        .expect((response) => {
+          expect(response.header['x-total-count']).toBe('3');
+          expect(response.body.length).toBe(1);
+          expect(response.body[0].id).toBe('testid8');
+        });
+
+      await request(app)
+        .get('/api/preprints-no-content?per-page=2&page=1&order=asc')
+        .expect(200)
+        .expect((response) => {
+          expect(response.header['x-total-count']).toBe('3');
+          expect(response.body.length).toBe(2);
+          expect(response.body[0].id).toBe('testid8');
+          expect(response.body[1].id).toBe('testid4');
+        });
+
+      await request(app)
+        .get('/api/preprints-no-content?per-page=2&page=2&order=asc')
+        .expect(200)
+        .expect((response) => {
+          expect(response.header['x-total-count']).toBe('3');
+          expect(response.body.length).toBe(1);
+          expect(response.body[0].id).toBe('testid6');
+        });
+
+      await request(app)
+        .get('/api/preprints-no-content?per-page=2&page=3&order=asc')
+        .expect(200)
+        .expect((response) => {
+          expect(response.header['x-total-count']).toBe('3');
+          expect(response.body.length).toBe(0);
         });
     });
   });

--- a/integration-tests/api.test.ts
+++ b/integration-tests/api.test.ts
@@ -1150,7 +1150,7 @@ describe('server tests', () => {
         .get('/api/preprints-no-content')
         .expect(200)
         .expect((response) => {
-          expect(response.header['X-Total-Count']).toBe('1');
+          expect(response.header.get('X-Total-Count')).toBe('1');
           expect(response.body.length).toBe(1);
           expect(response.body[0]).toEqual({
             id: 'testid4',

--- a/integration-tests/api.test.ts
+++ b/integration-tests/api.test.ts
@@ -1150,7 +1150,8 @@ describe('server tests', () => {
         .get('/api/preprints-no-content')
         .expect(200)
         .expect((response) => {
-          expect(response.body.length).toBe(2);
+          expect(response.header['X-Total-Count']).toBe('1');
+          expect(response.body.length).toBe(1);
           expect(response.body[0]).toEqual({
             id: 'testid4',
             msid: 'article.2',
@@ -1180,22 +1181,6 @@ describe('server tests', () => {
             publishedYear: 2023,
             subjects: ['subject 1', 'subject 2'],
             license: 'https://creativecommons.org/licenses/by/4.0/',
-          });
-          expect(response.body[1]).toEqual({
-            id: 'testid5',
-            versionIdentifier: '2',
-            msid: 'article.2',
-            doi: 'test/article.2',
-            preprintDoi: 'preprint/testdoi5',
-            preprintUrl: 'http://preprints.org/preprint/testdoi5',
-            preprintPosted: '2023-02-02T00:00:00.000Z',
-            article: {
-              title: 'Test Article 2',
-              authors: [],
-              licenses: [],
-              references: [],
-            },
-            published: null,
           });
         });
     });

--- a/src/controller/preprints-controller.ts
+++ b/src/controller/preprints-controller.ts
@@ -92,6 +92,10 @@ export const preprintsController = (repo: ArticleRepository) => {
       const perPage = parseInt(req.query['per-page'] as string, 10) || null;
 
       const articles = await repo.getEnhancedArticlesNoContent(page, perPage, order);
+      const total = await repo.getEnhancedArticlesNoContentTotal();
+
+      res.set('X-Total-Count', total.toString());
+
       res.send(articles);
     } catch (err) {
       next(err);

--- a/src/controller/preprints-controller.ts
+++ b/src/controller/preprints-controller.ts
@@ -87,7 +87,11 @@ export const preprintsController = (repo: ArticleRepository) => {
 
   const getEnhancedArticlesNoContent = async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const articles = await repo.getEnhancedArticlesNoContent();
+      const order = req.query.order as 'asc' | 'desc' || 'desc';
+      const page = parseInt(req.query.page as string, 10) || null;
+      const perPage = parseInt(req.query['per-page'] as string, 10) || null;
+
+      const articles = await repo.getEnhancedArticlesNoContent(page, perPage, order);
       res.send(articles);
     } catch (err) {
       next(err);

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -153,6 +153,6 @@ export interface ArticleRepository {
   storeEnhancedArticle(article: EnhancedArticle): Promise<boolean>;
   findArticleVersion(identifier: string, previews?: boolean): Promise<EnhancedArticleWithVersions | null>;
   getEnhancedArticleSummaries(): Promise<ArticleSummary[]>;
-  getEnhancedArticlesNoContent(): Promise<EnhancedArticleNoContent[]>;
+  getEnhancedArticlesNoContent(page: number | null, perPage: number | null, order: 'asc' | 'desc'): Promise<EnhancedArticleNoContent[]>;
   deleteArticleVersion(identifier: string): Promise<boolean>;
 }

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -141,6 +141,10 @@ export type EnhancedArticleNoContent = VersionSummary & {
   article: Omit<ProcessedArticle, 'doi' | 'date' | 'content' | 'abstract'>,
 };
 
+export type EnhancedArticleNoContentTotal = {
+  total: number,
+};
+
 export type EnhancedArticleWithVersions = {
   article: EnhancedArticle,
   versions: Record<string, VersionSummary>,
@@ -154,5 +158,6 @@ export interface ArticleRepository {
   findArticleVersion(identifier: string, previews?: boolean): Promise<EnhancedArticleWithVersions | null>;
   getEnhancedArticleSummaries(): Promise<ArticleSummary[]>;
   getEnhancedArticlesNoContent(page: number | null, perPage: number | null, order: 'asc' | 'desc'): Promise<EnhancedArticleNoContent[]>;
+  getEnhancedArticlesNoContentTotal(): Promise<number>;
   deleteArticleVersion(identifier: string): Promise<boolean>;
 }

--- a/src/model/mongodb/mongodb-repository.ts
+++ b/src/model/mongodb/mongodb-repository.ts
@@ -171,22 +171,51 @@ class MongoDBArticleRepository implements ArticleRepository {
     };
   }
 
-  async getEnhancedArticlesNoContent(): Promise<EnhancedArticleNoContent[]> {
-    const allVersions = await this.versionedCollection.find<EnhancedArticleNoContent>(
-      {},
+  async getEnhancedArticlesNoContent(page: number | null, perPage: number | null, order: 'asc' | 'desc'): Promise<EnhancedArticleNoContent[]> {
+    const allVersions = await this.versionedCollection.aggregate<EnhancedArticleNoContent>([
       {
-        projection: {
-          article: {
-            content: 0,
-            abstract: 0,
-            doi: 0,
-            date: 0,
-          },
+        $match: {
+          $and: [
+            { published: { $ne: null } },
+            { published: { $lte: new Date() } },
+          ],
+        },
+      },
+      {
+        $sort: { published: -1 },
+      },
+      {
+        $group: {
+          _id: '$msid',
+          mostRecentDocument: { $first: '$$ROOT' },
+          publishedDate: { $max: '$published' },
+        },
+      },
+      {
+        $sort: { publishedDate: (order === 'asc') ? 1 : -1 },
+      },
+      {
+        $replaceRoot: { newRoot: '$mostRecentDocument' },
+      },
+      {
+        $project: {
+          'article.content': 0,
+          'article.abstract': 0,
+          'article.doi': 0,
+          'article.date': 0,
           peerReview: 0,
           _id: 0,
         },
       },
-    ).toArray();
+      ...(page !== null && perPage !== null) ? [
+        {
+          $skip: (page - 1) * perPage,
+        },
+        {
+          $limit: perPage,
+        },
+      ] : [],
+    ]).toArray();
 
     return allVersions;
   }


### PR DESCRIPTION
The getEnhancedArticlesNoContent method in the Preprints Controller, Model, and MongoDB Repository now supports pagination and sorting. It accepts 'order' (asc/desc), 'page', and 'per-page' parameters and provides a default value when these parameters are not provided. The MongoDB query has been updated with aggregate pipeline operators for matching, sorting, and grouping the results.

With the page and per-page defaulting to null then the server api will continue to return all results until client explicitly sets those values.