### PR TITLE
feat: add secondary sorting in mongodb repository

### DIFF
--- a/src/model/mongodb/mongodb-repository.ts
+++ b/src/model/mongodb/mongodb-repository.ts
@@ -193,7 +193,7 @@ class MongoDBArticleRepository implements ArticleRepository {
         },
       },
       {
-        $sort: { publishedDate: (order === 'asc') ? 1 : -1 },
+        $sort: { publishedDate: (order === 'asc') ? 1 : -1, _id: (order === 'asc') ? 1 : -1 },
       },
       {
         $replaceRoot: { newRoot: '$mostRecentDocument' },


### PR DESCRIPTION
Add secondary sorting by _id in mongodb repository to ensure consistent ordering when 'publishedDate' is the same.