### PR TITLE
feat: Add support for 'Note' content type

### DIFF
--- a/integration-tests/mock-data/mock-body-1.json
+++ b/integration-tests/mock-data/mock-body-1.json
@@ -8056,6 +8056,35 @@
             }
           }
         ]
+      },
+      {
+        "type": "Paragraph",
+        "content": [
+          {
+            "type": "Note",
+            "id": "fn1",
+            "noteType": "Footnote",
+            "content": [
+              {
+                "type": "Paragraph",
+                "content": [
+                  {
+                    "type": "Superscript",
+                    "content": [
+                      "1"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "Paragraph",
+                "content": [
+                  "We avoid the term ‘place cell’ here because (1) that term has a technical meaning in the rodent hippocampus, whereas the arguments here extend to species that don’t have a hippocampus; (2) all the cells in this network have a place field, but it is smallest for the point cells."
+                ]
+              }
+            ]
+          }
+        ]
       }
     ],
     "references": [

--- a/src/http-schema/http-schema.ts
+++ b/src/http-schema/http-schema.ts
@@ -99,7 +99,7 @@ const ImageObjectContent = Joi.object({
 
 // These are not imported yet
 const OtherContent = Joi.object({
-  type: Joi.string().valid('CodeBlock', 'MathFragment', 'MediaObject', 'QuoteBlock', 'Table', 'ThematicBreak'),
+  type: Joi.string().valid('CodeBlock', 'MathFragment', 'MediaObject', 'QuoteBlock', 'Table', 'ThematicBreak', 'Note'),
 });
 // end block
 

--- a/src/model/content.ts
+++ b/src/model/content.ts
@@ -86,7 +86,7 @@ type ClaimContent = DecoratedContent & {
 };
 
 type OtherContent = {
-  type: 'CodeBlock' | 'MathFragment' | 'MediaObject' | 'Table' | 'ThematicBreak'
+  type: 'CodeBlock' | 'MathFragment' | 'MediaObject' | 'QuoteBlock' | 'Table' | 'ThematicBreak' | 'Note'
 };
 
 type ContentPart =


### PR DESCRIPTION
This commit adds support for a new content type 'Note' in our system. Changes include updates to mock data, http schema and model content. This will allow more diverse data to be included and processed in the preprints server.