### PR TITLE
Optimise double pipeline

### DIFF
--- a/src/controller/preprints-controller.ts
+++ b/src/controller/preprints-controller.ts
@@ -98,10 +98,9 @@ export const preprintsController = (repo: ArticleRepository) => {
       const page = parseInt(req.query.page as string, 10) || null;
       const perPage = parseInt(req.query['per-page'] as string, 10) || null;
 
-      const articles = await repo.getEnhancedArticlesNoContent(page, perPage, order);
-      const total = await repo.getEnhancedArticlesNoContentTotal();
+      const { articles, totalCount } = await repo.getEnhancedArticlesNoContent(page, perPage, order);
 
-      res.set('X-Total-Count', total.toString());
+      res.set('X-Total-Count', totalCount.toString());
 
       res.send(articles);
     } catch (err) {

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -144,13 +144,14 @@ export type EnhancedArticleNoContent = VersionSummary & {
   firstPublished: Date,
 };
 
-export type EnhancedArticleNoContentTotal = {
-  total: number,
-};
-
 export type EnhancedArticleWithVersions = {
   article: EnhancedArticle,
   versions: Record<string, VersionSummary>,
+};
+
+export type EnhancedArticlesNoContentWithTotal = {
+  totalCount: number,
+  articles: EnhancedArticleNoContent[],
 };
 
 export interface ArticleRepository {
@@ -160,7 +161,6 @@ export interface ArticleRepository {
   storeEnhancedArticle(article: EnhancedArticle): Promise<boolean>;
   findArticleVersion(identifier: string, previews?: boolean): Promise<EnhancedArticleWithVersions | null>;
   getEnhancedArticleSummaries(): Promise<ArticleSummary[]>;
-  getEnhancedArticlesNoContent(page: number | null, perPage: number | null, order: 'asc' | 'desc'): Promise<EnhancedArticleNoContent[]>;
-  getEnhancedArticlesNoContentTotal(): Promise<number>;
+  getEnhancedArticlesNoContent(page: number | null, perPage: number | null, order: 'asc' | 'desc'): Promise<EnhancedArticlesNoContentWithTotal>;
   deleteArticleVersion(identifier: string): Promise<boolean>;
 }


### PR DESCRIPTION
`optimise-no-content` branch:
```
> time curl  -s 'localhost:8080/api/preprints-no-content?per-page=100&page=1'  > /dev/null

real	0m0.648s
user	0m0.006s
sys	0m0.011s

[09:20:21] 650ms 0  ✔️
> time curl  -s 'localhost:8080/api/preprints-no-content?per-page=100&page=2'  > /dev/null

real	0m0.419s
user	0m0.006s
sys	0m0.012s

[09:20:25] 417ms 0  ✔️
> time curl  -s 'localhost:8080/api/preprints-no-content?per-page=100&page=3'  > /dev/null

real	0m0.483s
user	0m0.005s
sys	0m0.009s

[09:20:27] 492ms 0  ✔️
```

This branch:
```
> time curl  -s 'localhost:8080/api/preprints-no-content?per-page=100&page=1'  > /dev/null

real	0m0.151s
user	0m0.006s
sys	0m0.013s

[09:21:27] 140ms 0  ✔️
> time curl  -s 'localhost:8080/api/preprints-no-content?per-page=100&page=2'  > /dev/null

real	0m0.062s
user	0m0.006s
sys	0m0.011s

[09:21:30] 64ms 0  ✔️
> time curl  -s 'localhost:8080/api/preprints-no-content?per-page=100&page=3'  > /dev/null

real	0m0.065s
user	0m0.006s
sys	0m0.012s

[09:21:32] 65ms 0  ✔️
```